### PR TITLE
Allow assert to be used in function names

### DIFF
--- a/nix.YAML-tmLanguage
+++ b/nix.YAML-tmLanguage
@@ -329,7 +329,7 @@ repository:
     - include: '#others'
 
   with-assert:
-    begin: \b(with|assert)\b
+    begin: (?![\w-'])(with|assert)(?![\w-'])
     beginCaptures:
       '0': {name: keyword.other.nix}
     end: \;
@@ -602,5 +602,5 @@ repository:
 
   bad-reserved:
     # we don't mark "or" because it's a special case
-    match: \b(if|then|else|assert|with|let|in|rec|inherit)\b
+    match: (?![\w-'])(if|then|else|assert|with|let|in|rec|inherit)(?![\w-'])
     name: invalid.illegal.reserved.nix

--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -529,7 +529,7 @@
 		<key>bad-reserved</key>
 		<dict>
 			<key>match</key>
-			<string>\b(if|then|else|assert|with|let|in|rec|inherit)\b</string>
+			<string>(?![\w-'])(if|then|else|assert|with|let|in|rec|inherit)(?![\w-'])</string>
 			<key>name</key>
 			<string>invalid.illegal.reserved.nix</string>
 		</dict>
@@ -1770,7 +1770,7 @@
 		<key>with-assert</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(with|assert)\b</string>
+			<string>(?![\w-'])(with|assert)(?![\w-'])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Previously, the following would be incorrectly highlighted:

```nix
let 

    inherit (foo) assert-foo-bar;
in
    (assert-foo-bar foo-bar)
```


![screen shot 2017-06-01 at 8 34 13 am](https://cloud.githubusercontent.com/assets/76716/26679915/1df25480-46a5-11e7-800b-959c8bb07c4d.png)