### PR TITLE
Fix `assert`, `with` not being recognized as keywords

### DIFF
--- a/nix.YAML-tmLanguage
+++ b/nix.YAML-tmLanguage
@@ -329,7 +329,7 @@ repository:
     - include: '#others'
 
   with-assert:
-    begin: (?![\w'-])(with|assert)(?![\w'-])
+    begin: (?<![\w'-])(with|assert)(?![\w'-])
     beginCaptures:
       '0': {name: keyword.other.nix}
     end: \;
@@ -602,5 +602,5 @@ repository:
 
   bad-reserved:
     # we don't mark "or" because it's a special case
-    match: (?![\w'-])(if|then|else|assert|with|let|in|rec|inherit)(?![\w'-])
+    match: (?<![\w'-])(if|then|else|assert|with|let|in|rec|inherit)(?![\w'-])
     name: invalid.illegal.reserved.nix

--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -529,7 +529,7 @@
 		<key>bad-reserved</key>
 		<dict>
 			<key>match</key>
-			<string>(?![\w'-])(if|then|else|assert|with|let|in|rec|inherit)(?![\w'-])</string>
+			<string>(?&lt;![\w'-])(if|then|else|assert|with|let|in|rec|inherit)(?![\w'-])</string>
 			<key>name</key>
 			<string>invalid.illegal.reserved.nix</string>
 		</dict>
@@ -1770,7 +1770,7 @@
 		<key>with-assert</key>
 		<dict>
 			<key>begin</key>
-			<string>(?![\w'-])(with|assert)(?![\w'-])</string>
+			<string>(?&lt;![\w'-])(with|assert)(?![\w'-])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
This fixes issue #5.
Regex `(?![\w'-])(with|assert)` would never match because of negative lookahead. What was intended is negative lookbehind here.

Works with Sublime Text 3 build 3126. Doesn't have issues mentioned in neither #4 nor #5 .
