### PR TITLE
Fix regex for attribute names to allow unquoted substitutions

### DIFF
--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -386,7 +386,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?=(\s*\}|\"|\binherit\b|\b[a-zA-Z\_][a-zA-Z0-9\_\'\-]*(\s*\.|\s*=[^=])))</string>
+					<string>(?=(\s*\}|\"|\binherit\b|\b[a-zA-Z\_][a-zA-Z0-9\_\'\-]*(\s*\.|\s*=[^=])|\$\{[a-zA-z0-9\_\'\-]+\})(\s*\.|\s*=[^=]))</string>
 					<key>end</key>
 					<string>(?=([\])};,]|\b(else|then)\b))</string>
 					<key>patterns</key>


### PR DESCRIPTION
The following code snippet is currently valid Nix code:

```nix
let
  name = "foo";
in
{
  ${name} = "bar";
}
```

Until now the `attribute-or-function` matcher which is always used when
it's not clear if the current expression is an attribute set or a
function with an attribute set matching. The regex which should match an
attribute set inside the matcher didn't cover the case of such a
quoting.

Addresses #8 (but doesn't fix it yet)