### PR TITLE
Allow a tilde at the beginning of path expressions

### DIFF
--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -1661,7 +1661,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>([a-zA-Z0-9\.\_\-\+]*(\/[a-zA-Z0-9\.\_\-\+]+)+)</string>
+					<string>(~?[a-zA-Z0-9\.\_\-\+]*(\/[a-zA-Z0-9\.\_\-\+]+)+)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>


### PR DESCRIPTION
A path prefixed with a tilde as prefix is valid Nix code, but the
current module marks this as syntax error (checked with Nix 2.1.3)