### PR TITLE
Fix mistakenly set bracket in `attrset-or-function` matcher

### DIFF
--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -386,7 +386,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?=(\s*\}|\"|\binherit\b|\b[a-zA-Z\_][a-zA-Z0-9\_\'\-]*(\s*\.|\s*=[^=])|\$\{[a-zA-z0-9\_\'\-]+\})(\s*\.|\s*=[^=]))</string>
+					<string>(?=(\s*\}|\"|\binherit\b|\b[a-zA-Z\_][a-zA-Z0-9\_\'\-]*(\s*\.|\s*=[^=])|\$\{[a-zA-z0-9\_\'\-]+\}(\s*\.|\s*=[^=])))</string>
 					<key>end</key>
 					<string>(?=([\])};,]|\b(else|then)\b))</string>
 					<key>patterns</key>


### PR DESCRIPTION
It seems as one of the matching groups has been terminated way too early
which broke several cases of highlighting: https://github.com/wmertens/sublime-nix/pull/9#issuecomment-445025149

@ivan can you recheck please?
@wmertens sorry for this, can you have a look at this as well? :)