### PR TITLE
Adds pipe operator to operators list

### DIFF
--- a/nix.YAML-tmLanguage
+++ b/nix.YAML-tmLanguage
@@ -74,7 +74,7 @@ repository:
     - include: '#attrset-for-sure'
     - include: '#attrset-or-function'
     - name: keyword.operator.nix
-      match: (\bor\b|\.|==|!=|!|\<\=|\<|\>\=|\>|&&|\|\||-\>|//|\?|\+\+|-|\*|/(?=([^*]|$))|\+)
+      match: (\bor\b|\.|==|!=|!|\<\=|\<|\>\=|\>|&&|\|\||-\>|//|\?|\+\+|\|>|-|\*|/(?=([^*]|$))|\+)
     - include: '#constants'
     - include: '#bad-reserved'
     - include: '#parameter-name'

--- a/nix.tmLanguage
+++ b/nix.tmLanguage
@@ -755,7 +755,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(\bor\b|\.|==|!=|!|\&lt;\=|\&lt;|\&gt;\=|\&gt;|&amp;&amp;|\|\||-\&gt;|//|\?|\+\+|-|\*|/(?=([^*]|$))|\+)</string>
+					<string>(\bor\b|\.|==|!=|!|\&lt;\=|\&lt;|\&gt;\=|\&gt;|&amp;&amp;|\|\||-\&gt;|//|\?|\+\+|\|>|-|\*|/(?=([^*]|$))|\+)</string>
 					<key>name</key>
 					<string>keyword.operator.nix</string>
 				</dict>


### PR DESCRIPTION
Really easy to navigate – well done! 

I have experimental pipes enabled locally so I added this for my own purposes, figured they wouldn't hurt for anyone not using them (and hopefully the nix `|>` operator will be merged into trunk).